### PR TITLE
Fix UX when loading more posts (at cost of DX)

### DIFF
--- a/components/gqless/PostList.js
+++ b/components/gqless/PostList.js
@@ -2,9 +2,7 @@ import { useState } from 'react'
 import { graphql, useVariable } from '@gqless/react'
 import { useGqless } from '../../lib/gqless'
 import PostUpvoter from '../gqless/PostUpvoter'
-
-const flat = input => [].concat(...input)
-const flatMap = (array, callback) => flat(array.map(callback))
+import Suspense from '../../lib/SsrCompatibleSuspense'
 
 export const getAllPostsArgs = pageNumber => ({
   skip: pageNumber * 10,
@@ -16,22 +14,18 @@ const PostList = () => {
   const {query} = useGqless()
   const [numberOfPages, setNumberOfPages] = useState(1)
   const loadAnotherPage = () => setNumberOfPages(n => n + 1)
-  const posts = flatMap(
-    Array.from({length: numberOfPages}),
-    (_, index) => query.allPosts(getAllPostsArgs(index))
-  )
-  const areMorePosts = posts.length < query._allPostsMeta.count
+  const postPages = Array.from({length: numberOfPages})
+    .map((_, index) => query.allPosts(getAllPostsArgs(index)))
+  const numberOfVisiblePosts = postPages.reduce((subtotal, posts) => subtotal + posts.length, 0)
+  const totalNumberOfPosts = query._allPostsMeta.count
+  const areMorePosts = numberOfVisiblePosts < totalNumberOfPosts
   return (
     <section>
       <ul>
-        {posts.map((post, index) => (
-          <li key={index}>
-            <div>
-              <span>{index + 1}. </span>
-              <a href={post.url}>{post.title}</a>
-              <PostUpvoter post={post}/>
-            </div>
-          </li>
+        {postPages.map((posts, pageNumber) => (
+          <Suspense key={pageNumber} fallback={<div>Loading more...</div>}>
+            <PostPage pageNumber={pageNumber} posts={posts}/>
+          </Suspense>
         ))}
       </ul>
       {areMorePosts && (
@@ -42,25 +36,6 @@ const PostList = () => {
       <style jsx>{`
         section {
           padding-bottom: 20px;
-        }
-        li {
-          display: block;
-          margin-bottom: 10px;
-        }
-        div {
-          align-items: center;
-          display: flex;
-        }
-        a {
-          font-size: 14px;
-          margin-right: 10px;
-          text-decoration: none;
-          padding-bottom: 0;
-          border: 0;
-        }
-        span {
-          font-size: 14px;
-          margin-right: 5px;
         }
         ul {
           margin: 0;
@@ -80,4 +55,40 @@ const PostList = () => {
     </section>
   )
 };
+
+const PostPage = graphql(({pageNumber, posts}) => {
+  return (<>
+    {posts.map((post, index) => (
+      <li key={index}>
+        <div>
+          <span>{(pageNumber * 10) + index + 1}. </span>
+          <a href={post.url}>{post.title}</a>
+          <PostUpvoter post={post}/>
+        </div>
+      </li>
+    ))}
+    <style jsx>{`
+      li {
+        display: block;
+        margin-bottom: 10px;
+      }
+      div {
+        align-items: center;
+        display: flex;
+      }
+      span {
+        font-size: 14px;
+        margin-right: 5px;
+      }
+      a {
+        font-size: 14px;
+        margin-right: 10px;
+        text-decoration: none;
+        padding-bottom: 0;
+        border: 0;
+      }
+    `}</style>
+  </>)
+})
+
 export default graphql(PostList)


### PR DESCRIPTION
You can see in the [deployment for master branch](https://next-with-gqless-example.now.sh/gqless/ssr) that the UX sucks when use clicks "Show More". Try it. When the data is being fetched, the list whole PostList component disappears and a single "Loading" message is shown. 

This PR makes some changes to fix that, but I'm not sure I want to merge it, because of how it forces us structure our app tree ☹️. See code changes. I was forced to move a lot of code from PostList to a new graphql component inside another <Suspense> element. It's not very ergonomic to be forced in this way. Maybe there's a better solution..